### PR TITLE
Composer autoloading broken

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,7 @@
         "cypresslab/gitelephant": "0.8.*"
     },
     "autoload": {
-        "autoload": {
-            "psr-0": { "Cypress\\GitElephantBundle": "" }
-        }
+        "psr-0": { "Cypress\\GitElephantBundle": "" }
     },
     "target-dir": "Cypress/GitElephantBundle"
 }


### PR DESCRIPTION
Syntax in composer.json file was incorrect, which broke the automated autoloading of the bundle.
Fixed in PR :)
